### PR TITLE
remove SwiftLint Plugin from package

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Lint
+      run: swiftlint
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,24 +19,6 @@
       }
     },
     {
-      "identity" : "collectionconcurrencykit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
-      "state" : {
-        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-        "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "cryptoswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
-      "state" : {
-        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
-        "version" : "1.8.1"
-      }
-    },
-    {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
@@ -46,75 +28,12 @@
       }
     },
     {
-      "identity" : "sourcekitten",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/SourceKitten.git",
-      "state" : {
-        "revision" : "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
-        "version" : "0.34.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
         "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
         "version" : "1.5.4"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
-        "version" : "509.0.2"
-      }
-    },
-    {
-      "identity" : "swiftlint",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/SwiftLint",
-      "state" : {
-        "revision" : "f17a4f9dfb6a6afb0408426354e4180daaf49cee",
-        "version" : "0.54.0"
-      }
-    },
-    {
-      "identity" : "swiftytexttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
-      "state" : {
-        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swxmlhash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/drmohundro/SWXMLHash.git",
-      "state" : {
-        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
-        "version" : "7.0.2"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-        "version" : "5.0.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,15 +16,13 @@ let package = Package(
             targets: ["AnthropicSwiftSDK"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/realm/SwiftLint", .upToNextMajor(from: "0.54.0")),
         .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "0.32.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "AnthropicSwiftSDK",
-            plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
+            name: "AnthropicSwiftSDK"
         ),
         .testTarget(
             name: "AnthropicSwiftSDKTests",

--- a/Package.swift
+++ b/Package.swift
@@ -31,10 +31,12 @@ let package = Package(
             name: "AnthropicSwiftSDK-Bedrock",
             dependencies: [
                 "AnthropicSwiftSDK",
-                .product(name: "AWSBedrockRuntime", package: "aws-sdk-swift")]),
+                .product(name: "AWSBedrockRuntime", package: "aws-sdk-swift")
+            ]),
         .testTarget(
             name: "AnthropicSwiftSDK-BedrockTests",
             dependencies: [
-                "AnthropicSwiftSDK-Bedrock"])
+                "AnthropicSwiftSDK-Bedrock"
+            ])
     ]
 )

--- a/Sources/AnthropicSwiftSDK-Bedrock/AnthropicBedrockClientError.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/AnthropicBedrockClientError.swift
@@ -9,8 +9,8 @@ import Foundation
 import AWSBedrockRuntime
 
 public enum AnthropicBedrockClientError: Error {
-    case cannotGetAnyDataFromBedrockMessageResponse(InvokeModelOutput)
-    case cannotGetAnyDataFromBedrockStreamResponse(InvokeModelWithResponseStreamOutput)
+    case cannotGetDataFromBedrockMessageResponse(InvokeModelOutput)
+    case cannotGetDataFromBedrockStreamResponse(InvokeModelWithResponseStreamOutput)
     case bedrockRuntimeClientGetsUnknownPayload(BedrockRuntimeClientTypes.ResponseStream)
-    case cannotGetAnyDataFromBedrockRuntimeClientPayload(BedrockRuntimeClientTypes.PayloadPart)
+    case cannotGetDataFromBedrockClientPayload(BedrockRuntimeClientTypes.PayloadPart)
 }

--- a/Sources/AnthropicSwiftSDK-Bedrock/Messages.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/Messages.swift
@@ -107,8 +107,9 @@ extension BedrockRuntimeClientTypes.ResponseStream {
             throw AnthropicBedrockClientError.bedrockRuntimeClientGetsUnknownPayload(self)
         }
 
-        guard let data = payload.bytes,
-              let line = String(data: data, encoding: .utf8) else {
+        guard
+            let data = payload.bytes,
+            let line = String(data: data, encoding: .utf8) else {
             throw AnthropicBedrockClientError.cannotGetAnyDataFromBedrockRuntimeClientPayload(payload)
         }
 

--- a/Sources/AnthropicSwiftSDK/Network/StreamingParser/AnthropicStreamingParser.swift
+++ b/Sources/AnthropicSwiftSDK/Network/StreamingParser/AnthropicStreamingParser.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public enum AnthropicStreamingParser {
+    // swiftlint:disable:next cyclomatic_complexity
     public static func parse<T: AsyncSequence>(stream: T) async throws -> AsyncThrowingStream<StreamingResponse, Error> where T.Element == String {
         return AsyncThrowingStream.init { continuation in
             let task = Task {


### PR DESCRIPTION
fixes: https://github.com/fumito-ito/AnthropicSwiftSDK/issues/4

Because the SwiftLint Plugin is included in the package, a warning dialog will appear when running it in Xcode.
This is safe, but annoying. This PR changes CI to check for Lint and removes the SwiftLint Plugin.