### PR TITLE
Fix issue with incorrect parameters being included in requests when using AWS Bedrock

### DIFF
--- a/Sources/AnthropicSwiftSDK-Bedrock/Extensions/InvokeModelInput+Extension.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/Extensions/InvokeModelInput+Extension.swift
@@ -17,7 +17,10 @@ extension InvokeModelInput {
     ///   - request: Claude API request. It will be converted to `Data` and contained in bedrock request.
     ///   - contentType: acceptable request content type
     init(accept: String, request: MessagesRequest, contentType: String) throws {
-        let data = try request.encode(with: ["anthropic_version": AnthropicBedrockClient.anthropicVersion])
+        let data = try request.encode(
+            with: ["anthropic_version": AnthropicBedrockClient.anthropicVersion],
+            without: UnnecessaryParameter.allCases.map { $0.rawValue }
+        )
 
         self.init(
             accept: accept,

--- a/Sources/AnthropicSwiftSDK-Bedrock/Extensions/InvokeModelWithResponseStreamInput+Extension.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/Extensions/InvokeModelWithResponseStreamInput+Extension.swift
@@ -17,7 +17,10 @@ extension InvokeModelWithResponseStreamInput {
     ///   - request: Claude API request. It will be converted to `Data` and contained in bedrock request.
     ///   - contentType: acceptable request content type
     init(accept: String, request: MessagesRequest, contentType: String) throws {
-        let data = try request.encode(with: ["anthropic_version": AnthropicBedrockClient.anthropicVersion])
+        let data = try request.encode(
+            with: ["anthropic_version": AnthropicBedrockClient.anthropicVersion],
+            without: UnnecessaryParameter.allCases.map { $0.rawValue }
+        )
 
         self.init(
             accept: accept,

--- a/Sources/AnthropicSwiftSDK-Bedrock/Messages.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/Messages.swift
@@ -99,7 +99,7 @@ public struct Messages {
         topP: Double? = nil,
         topK: Int? = nil
     ) async throws -> AsyncThrowingStream<StreamingResponse, Error> {
-        // In the inference call, fill the body field with a JSON object that conforms the type call you want to make [Anthropic Claude Messages API](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html).
+        // In the inference call, fill the body field with a JSON object that conforms the type call you want to make [Anthropic Claude Messages API](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html ).
         let requestBody = MessagesRequest(
             model: model,
             messages: messages,
@@ -135,12 +135,10 @@ extension BedrockRuntimeClientTypes.ResponseStream {
             throw AnthropicBedrockClientError.bedrockRuntimeClientGetsUnknownPayload(self)
         }
 
-        guard
-            let data = payload.bytes,
-            let line = String(data: data, encoding: .utf8) else {
+        guard let data = payload.bytes else {
             throw AnthropicBedrockClientError.cannotGetDataFromBedrockClientPayload(payload)
         }
 
-        return line
+        return String(decoding: data, as: UTF8.self)
     }
 }

--- a/Sources/AnthropicSwiftSDK-Bedrock/UnnecessaryParameter.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/UnnecessaryParameter.swift
@@ -1,0 +1,17 @@
+//
+//  UnnecessaryParameter.swift
+//
+//
+//  Created by 伊藤史 on 2024/07/01.
+//
+
+import Foundation
+
+/// Unnecessary parameters to use Anthropic claude through AWS Bedrock
+///
+/// When using the Anthropic API through AWS Bedrock, some of the properties required in a normal Anthropic API request were causing errors as invalid properties.
+enum UnnecessaryParameter: String, CaseIterable {
+    case model
+    case stream
+    case metadata
+}

--- a/Sources/AnthropicSwiftSDK/Network/MessagesRequest.swift
+++ b/Sources/AnthropicSwiftSDK/Network/MessagesRequest.swift
@@ -74,7 +74,7 @@ public struct MessagesRequest: Encodable {
 }
 
 extension MessagesRequest {
-    public func encode(with appendingObject: [String: Any]) throws -> Data {
+    public func encode(with appendingObject: [String: Any], without removingObjectKeys: [String] = []) throws -> Data {
         let encoded = try anthropicJSONEncoder.encode(self)
         guard var dictionary = try JSONSerialization.jsonObject(with: encoded, options: []) as? [String: Any] else {
             return encoded
@@ -82,6 +82,10 @@ extension MessagesRequest {
 
         appendingObject.forEach { key, value in
             dictionary[key] = value
+        }
+
+        removingObjectKeys.forEach { key in
+            dictionary.removeValue(forKey: key)
         }
 
         return try JSONSerialization.data(withJSONObject: dictionary, options: [])


### PR DESCRIPTION
refs: #19 

When using the Anthropic API through AWS Bedrock, some of the properties required in a normal Anthropic API request were causing errors as invalid properties.

Specifically, the following properties were incorrect
- model
- metadata
- stream

For more information, please refer to the AWS documentation. https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html