### PR TITLE
Fixes a problem with AWSBedrock's parse method for Stream Response, which was incorrect.

### DIFF
--- a/Sources/AnthropicSwiftSDK-Bedrock/AnthropicBedrockClientError.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/AnthropicBedrockClientError.swift
@@ -13,4 +13,5 @@ public enum AnthropicBedrockClientError: Error {
     case cannotGetDataFromBedrockStreamResponse(InvokeModelWithResponseStreamOutput)
     case bedrockRuntimeClientGetsUnknownPayload(BedrockRuntimeClientTypes.ResponseStream)
     case cannotGetDataFromBedrockClientPayload(BedrockRuntimeClientTypes.PayloadPart)
+    case bedrockRuntimeClientGetsErrorInStream(String)
 }

--- a/Sources/AnthropicSwiftSDK-Bedrock/Extensions/AnthropicStreamingParser+Extension.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/Extensions/AnthropicStreamingParser+Extension.swift
@@ -1,0 +1,70 @@
+//
+//  AnthropicStreamingParser+Extension.swift
+//
+//
+//  Created by 伊藤史 on 2024/07/02.
+//
+
+import Foundation
+import AnthropicSwiftSDK
+import AWSBedrockRuntime
+
+extension AnthropicStreamingParser {
+    // swiftlint:disable:next cyclomatic_complexity
+    static func parse(responseStream element: BedrockRuntimeClientTypes.ResponseStream) throws -> StreamingResponse {
+        switch element {
+        case .chunk(let payload):
+            guard let data = payload.bytes else {
+                throw AnthropicBedrockClientError.cannotGetDataFromBedrockClientPayload(payload)
+            }
+
+            let responseType = try anthropicJSONDecoder.decode(
+                StreamingBaseResponse.self,
+                from: data
+            ).type
+
+            switch responseType {
+            case .messageStart:
+                return try anthropicJSONDecoder.decode(StreamingMessageStartResponse.self, from: data)
+            case .contentBlockStart:
+                return try anthropicJSONDecoder.decode(StreamingContentBlockStartResponse.self, from: data)
+            case .contentBlockDelta:
+                return try anthropicJSONDecoder.decode(StreamingContentBlockDeltaResponse.self, from: data)
+            case .contentBlockStop:
+                return try anthropicJSONDecoder.decode(StreamingContentBlockStopResponse.self, from: data)
+            case .messageDelta:
+                return try anthropicJSONDecoder.decode(StreamingMessageDeltaResponse.self, from: data)
+            case .messageStop:
+                return try anthropicJSONDecoder.decode(StreamingMessageStopResponse.self, from: data)
+            case .ping:
+                return try anthropicJSONDecoder.decode(StreamingPingResponse.self, from: data)
+            case .error:
+                return try anthropicJSONDecoder.decode(StreamingErrorResponse.self, from: data)
+            }
+        case .sdkUnknown(let error):
+            throw AnthropicBedrockClientError.bedrockRuntimeClientGetsErrorInStream(error)
+        }
+    }
+
+    static func parseBedrockStream<T: AsyncSequence>(_ stream: T) async throws -> AsyncThrowingStream<StreamingResponse, Error> where T.Element == BedrockRuntimeClientTypes.ResponseStream {
+        return AsyncThrowingStream.init { continuation in
+            let task = Task {
+                for try await element in stream {
+                    do {
+                        continuation.yield(try parse(responseStream: element))
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+            }
+
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+}
+
+struct StreamingBaseResponse: StreamingResponse {
+    var type: StreamingEvent
+}

--- a/Sources/AnthropicSwiftSDK-Bedrock/Messages.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/Messages.swift
@@ -125,7 +125,7 @@ public struct Messages {
             throw AnthropicBedrockClientError.cannotGetDataFromBedrockStreamResponse(response)
         }
 
-        return try await AnthropicStreamingParser.parse(stream: responseStream.map { try $0.toString() })
+        return try await AnthropicStreamingParser.parseBedrockStream(responseStream)
     }
 }
 
@@ -135,12 +135,10 @@ extension BedrockRuntimeClientTypes.ResponseStream {
             throw AnthropicBedrockClientError.bedrockRuntimeClientGetsUnknownPayload(self)
         }
 
-        guard
-            let data = payload.bytes,
-            let line = String(data: data, encoding: .utf8) else {
+        guard let data = payload.bytes else {
             throw AnthropicBedrockClientError.cannotGetDataFromBedrockClientPayload(payload)
         }
 
-        return line
+        return String(decoding: data, as: UTF8.self)
     }
 }

--- a/Tests/AnthropicSwiftSDK-BedrockTests/AnthropicBedrockMessagesResponseParserTests.swift
+++ b/Tests/AnthropicSwiftSDK-BedrockTests/AnthropicBedrockMessagesResponseParserTests.swift
@@ -1,0 +1,115 @@
+//
+//  AnthropicBedrockMessagesResponseParserTests.swift
+//  
+//
+//  Created by 伊藤史 on 2024/07/03.
+//
+
+import XCTest
+@testable import AnthropicSwiftSDK
+import AWSBedrockRuntime
+@testable import AnthropicSwiftSDK_Bedrock
+
+final class AnthropicBedrockMessagesResponseParserTests: XCTestCase {
+    func testParseMessageStartData() throws {
+        let data = """
+        {"type": "message_start", "message": {"id": "msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY", "type": "message", "role": "assistant", "content": [], "model": "claude-3-opus-20240229", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 25, "output_tokens": 1}}}
+        """
+        let response = BedrockRuntimeClientTypes.ResponseStream.chunk(.init(bytes: data.data(using: .utf8)))
+        let result = try AnthropicStreamingParser.parse(responseStream: response) as! StreamingMessageStartResponse
+
+        XCTAssertEqual(result.type, .messageStart)
+        XCTAssertEqual(result.message.id, "msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY")
+        XCTAssertEqual(result.message.type, .message)
+        XCTAssertEqual(result.message.role, .assistant)
+        XCTAssert(result.message.content.isEmpty)
+        XCTAssertEqual(result.message.model?.stringfy, "claude-3-opus-20240229")
+        XCTAssertNil(result.message.stopReason)
+        XCTAssertNil(result.message.stopSequence)
+        XCTAssertEqual(result.message.usage.inputTokens, 25)
+        XCTAssertEqual(result.message.usage.outputTokens, 1)
+    }
+
+    func testParseMessageDeltaData() throws {
+        let data = """
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence":null}, "usage":{"output_tokens": 15}}
+        """
+        let response = BedrockRuntimeClientTypes.ResponseStream.chunk(.init(bytes: data.data(using: .utf8)))
+        let result = try AnthropicStreamingParser.parse(responseStream: response) as! StreamingMessageDeltaResponse
+
+        XCTAssertEqual(result.type, .messageDelta)
+        XCTAssertEqual(result.delta.stopReason, .endTurn)
+        XCTAssertNil(result.delta.stopSequence)
+        XCTAssertEqual(result.usage.outputTokens, 15)
+        XCTAssertNil(result.usage.inputTokens)
+    }
+
+    func testParseMessageStopData() throws {
+        let data = """
+        {"type": "message_stop"}
+        """
+        let response = BedrockRuntimeClientTypes.ResponseStream.chunk(.init(bytes: data.data(using: .utf8)))
+        let result = try AnthropicStreamingParser.parse(responseStream: response) as! StreamingMessageStopResponse
+
+        XCTAssertEqual(result.type, .messageStop)
+    }
+
+    func testParseContentBlockStartData() throws {
+        let data = """
+        {"type": "content_block_start", "index":0, "content_block": {"type": "text", "text": ""}}
+        """
+        let response = BedrockRuntimeClientTypes.ResponseStream.chunk(.init(bytes: data.data(using: .utf8)))
+        let result = try AnthropicStreamingParser.parse(responseStream: response) as! StreamingContentBlockStartResponse
+
+        XCTAssertEqual(result.type, .contentBlockStart)
+        XCTAssertEqual(result.index, 0)
+        XCTAssertEqual(result.contentBlock.type, "text")
+        XCTAssertEqual(result.contentBlock.text, "")
+    }
+
+    func testParseContentBlockDeltaData() throws {
+        let data = """
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}
+        """
+        let response = BedrockRuntimeClientTypes.ResponseStream.chunk(.init(bytes: data.data(using: .utf8)))
+        let result = try AnthropicStreamingParser.parse(responseStream: response) as! StreamingContentBlockDeltaResponse
+
+        XCTAssertEqual(result.type, .contentBlockDelta)
+        XCTAssertEqual(result.index, 0)
+        XCTAssertEqual(result.delta.type, "text_delta")
+        XCTAssertEqual(result.delta.text, "Hello")
+    }
+
+    func testParseContentBlockStopData() throws {
+        let data = """
+        {"type": "content_block_stop", "index": 0}
+        """
+        let response = BedrockRuntimeClientTypes.ResponseStream.chunk(.init(bytes: data.data(using: .utf8)))
+        let result = try AnthropicStreamingParser.parse(responseStream: response) as! StreamingContentBlockStopResponse
+
+        XCTAssertEqual(result.type, .contentBlockStop)
+        XCTAssertEqual(result.index, 0)
+    }
+
+    func testParsePingData() throws {
+        let data = """
+        {"type": "ping"}
+        """
+        let response = BedrockRuntimeClientTypes.ResponseStream.chunk(.init(bytes: data.data(using: .utf8)))
+        let result = try AnthropicStreamingParser.parse(responseStream: response) as! StreamingPingResponse
+
+        XCTAssertEqual(result.type, .ping)
+    }
+
+    func testParserErrorData() throws {
+        let data = """
+        {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}
+        """
+        let response = BedrockRuntimeClientTypes.ResponseStream.chunk(.init(bytes: data.data(using: .utf8)))
+        let result = try AnthropicStreamingParser.parse(responseStream: response) as! StreamingErrorResponse
+
+        XCTAssertEqual(result.type, .error)
+        XCTAssertEqual(result.error.type, .overloadedError)
+        XCTAssertEqual(result.error.message, "Overloaded")
+    }
+}


### PR DESCRIPTION
refs: #19 

AWSBedrock parses Claude's response and returns only the `data: ` part as response body. If the `AnthropicStreamingParser` parses this data as it is, the parse will fail, so a function to parse AWSBedrock's response is added.