### PR TITLE
remove invalid request parameter for VertexAI

### DIFF
--- a/Sources/AnthropicSwiftSDK-VertexAI/Entity/SupportedRegion.swift
+++ b/Sources/AnthropicSwiftSDK-VertexAI/Entity/SupportedRegion.swift
@@ -19,4 +19,12 @@ public enum SupportedRegion: String {
     ///
     /// This region supports only Claude 3 Haiku
     case europeWest4 = "europe-west4"
+    /// europe-west1 region
+    ///
+    /// This region supports only Claude 3.5 Sonnet
+    case europeWest1 = "europe-west1"
+    /// us-east5 region
+    ///
+    /// This region supports only Claude 3.5 Sonnet
+    case usEast5 = "us-east5"
 }

--- a/Sources/AnthropicSwiftSDK-VertexAI/Network/VertexAIClient.swift
+++ b/Sources/AnthropicSwiftSDK-VertexAI/Network/VertexAIClient.swift
@@ -80,7 +80,10 @@ struct VertexAIClient {
             request.setValue(value, forHTTPHeaderField: key)
         }
         request.httpMethod = method.rawValue
-        request.httpBody = try requestBody.encode(with: ["anthropic_version": anthropicVersion])
+        request.httpBody = try requestBody.encode(
+            with: ["anthropic_version": anthropicVersion],
+            without: UnnecessaryParameter.allCases.map { $0.rawValue }
+        )
 
         return try await session.data(for: request)
     }
@@ -91,7 +94,10 @@ struct VertexAIClient {
             request.setValue(value, forHTTPHeaderField: key)
         }
         request.httpMethod = method.rawValue
-        request.httpBody = try requestBody.encode(with: ["anthropic_version": anthropicVersion])
+        request.httpBody = try requestBody.encode(
+            with: ["anthropic_version": anthropicVersion],
+            without: UnnecessaryParameter.allCases.map { $0.rawValue }
+        )
 
         return try await session.bytes(for: request)
     }

--- a/Sources/AnthropicSwiftSDK-VertexAI/UnnecessaryParameter.swift
+++ b/Sources/AnthropicSwiftSDK-VertexAI/UnnecessaryParameter.swift
@@ -1,0 +1,15 @@
+//
+//  UnnecessaryParameter.swift
+//  
+//
+//  Created by 伊藤史 on 2024/07/10.
+//
+
+import Foundation
+
+/// Unnecessary parameters to use Anthropic claude through VertexAI
+///
+/// When using the Anthropic API through VertexAI, some of the properties required in a normal Anthropic API request were causing errors as invalid properties.
+enum UnnecessaryParameter: String, CaseIterable {
+    case model
+}


### PR DESCRIPTION
The `model` parameter is not allowed in VertexAI. Therefore, this change removes the `model` parameter when accessing VertexAI.

Also, when accessing Anthropic Claude 3.5 Sonnet from VertexAI, you need to go through a specific region.