### PR TITLE
Cache control support

### DIFF
--- a/Sources/AnthropicSwiftSDK-Bedrock/Messages.swift
+++ b/Sources/AnthropicSwiftSDK-Bedrock/Messages.swift
@@ -38,7 +38,7 @@ public struct Messages {
     public func createMessage(
         _ messages: [Message],
         model: Model = .claude_3_Haiku,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,
@@ -88,7 +88,7 @@ public struct Messages {
     public func streamMessage(
         _ messages: [Message],
         model: Model = .claude_3_Haiku,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,

--- a/Sources/AnthropicSwiftSDK-VertexAI/Messages.swift
+++ b/Sources/AnthropicSwiftSDK-VertexAI/Messages.swift
@@ -38,7 +38,7 @@ public struct Messages {
     public func createMessage(
         _ messages: [Message],
         model: Model = .claude_3_Haiku,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,
@@ -92,7 +92,7 @@ public struct Messages {
     public func streamMessage(
         _ messages: [Message],
         model: Model = .claude_3_Haiku,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,

--- a/Sources/AnthropicSwiftSDK/ClientError.swift
+++ b/Sources/AnthropicSwiftSDK/ClientError.swift
@@ -33,6 +33,8 @@ public enum ClientError: Error {
     case failedToDecodeToolUseContent
     /// SDK failed to make `ToolUse.input` encodable
     case failedToMakeEncodableToolUseInput([String: Any])
+    /// SDK failed to encode `SystemPrompt` object
+    case failedToEncodeSystemPrompt
 
     /// Description of sdk internal errors.
     public var localizedDescription: String {
@@ -59,6 +61,8 @@ public enum ClientError: Error {
             return "Failed to decode into tool use content"
         case .failedToMakeEncodableToolUseInput:
             return "Failed to make ToolUse.input object Encodable"
+        case .failedToEncodeSystemPrompt:
+            return "Failed to encode `SystemPrompt` object"
         }
     }
 }

--- a/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
+++ b/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
@@ -7,11 +7,28 @@
 
 import Foundation
 
-public enum CacheControl {
+public enum CacheControl: String, Encodable {
     /// corresponds to this 5-minute lifetime.
     case ephemeral
 }
 
 public enum SystemPrompt {
     case text(String, CacheControl?)
+}
+
+extension SystemPrompt: Encodable {
+    enum CodingKeys: CodingKey {
+        case text
+        case cacheControl
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        guard case let .text(text, cacheControl) = self else {
+            fatalError()
+        }
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(text, forKey: .text)
+        try container.encode(cacheControl, forKey: .cacheControl)
+    }
 }

--- a/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
+++ b/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
@@ -35,10 +35,10 @@ public enum SystemPrompt {
 }
 
 extension SystemPrompt: Encodable {
-    enum CodingKeys: CodingKey {
+    enum CodingKeys: String, CodingKey {
         case type
         case text
-        case cache_control
+        case cacheControl = "cache_control"
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -50,7 +50,7 @@ extension SystemPrompt: Encodable {
         try container.encode(type, forKey: .type)
         try container.encode(text, forKey: .text)
         if let cacheControl {
-            try container.encode(cacheControl, forKey: .cache_control)
+            try container.encode(cacheControl, forKey: .cacheControl)
         }
     }
 }

--- a/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
+++ b/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
@@ -24,7 +24,7 @@ extension SystemPrompt: Encodable {
 
     public func encode(to encoder: any Encoder) throws {
         guard case let .text(text, cacheControl) = self else {
-            fatalError()
+            throw ClientError.failedToEncodeSystemPrompt
         }
 
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
+++ b/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
@@ -1,0 +1,17 @@
+//
+//  SystemPrompt.swift
+//
+//
+//  Created by 伊藤史 on 2024/09/04.
+//
+
+import Foundation
+
+public enum CacheControl {
+    /// corresponds to this 5-minute lifetime.
+    case ephemeral
+}
+
+public enum SystemPrompt {
+    case text(String, CacheControl?)
+}

--- a/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
+++ b/Sources/AnthropicSwiftSDK/Entity/SystemPrompt.swift
@@ -7,19 +7,38 @@
 
 import Foundation
 
-public enum CacheControl: String, Encodable {
+public enum CacheControl: String {
     /// corresponds to this 5-minute lifetime.
     case ephemeral
 }
 
+extension CacheControl: Encodable {
+    enum CodingKeys: CodingKey {
+        case type
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.rawValue, forKey: .type)
+    }
+}
+
 public enum SystemPrompt {
     case text(String, CacheControl?)
+
+    private var type: String {
+        switch self {
+        case .text:
+            return "text"
+        }
+    }
 }
 
 extension SystemPrompt: Encodable {
     enum CodingKeys: CodingKey {
+        case type
         case text
-        case cacheControl
+        case cache_control
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -28,7 +47,10 @@ extension SystemPrompt: Encodable {
         }
 
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
         try container.encode(text, forKey: .text)
-        try container.encode(cacheControl, forKey: .cacheControl)
+        if let cacheControl {
+            try container.encode(cacheControl, forKey: .cache_control)
+        }
     }
 }

--- a/Sources/AnthropicSwiftSDK/Messages.swift
+++ b/Sources/AnthropicSwiftSDK/Messages.swift
@@ -39,7 +39,7 @@ public struct Messages {
     public func createMessage(
         _ messages: [Message],
         model: Model = .claude_3_Opus,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,
@@ -87,7 +87,7 @@ public struct Messages {
     public func createMessage(
         _ messages: [Message],
         model: Model = .claude_3_Opus,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,
@@ -177,7 +177,7 @@ public struct Messages {
         forToolUseRequest toolUseRequest: MessagesResponse,
         priviousMessages messages: [Message],
         model: Model = .claude_3_Opus,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,
@@ -240,7 +240,7 @@ public struct Messages {
     public func streamMessage(
         _ messages: [Message],
         model: Model = .claude_3_Opus,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,
@@ -288,7 +288,7 @@ public struct Messages {
     public func streamMessage(
         _ messages: [Message],
         model: Model = .claude_3_Opus,
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequence: [String]? = nil,
@@ -374,7 +374,7 @@ public struct Messages {
         _ stream: AsyncThrowingStream<StreamingResponse, Error>,
         messages: [Message],
         model: Model,
-        system: String?,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData?,
         stopSequence: [String]?,

--- a/Sources/AnthropicSwiftSDK/Network/HeaderProvider/AnthropicHeaderProvider.swift
+++ b/Sources/AnthropicSwiftSDK/Network/HeaderProvider/AnthropicHeaderProvider.swift
@@ -20,7 +20,7 @@ struct DefaultAnthropicHeaderProvider: AnthropicHeaderProvider {
     /// content type of response, now only support JSON
     let contentType = "application/json"
 
-    private let betaDescription = "messages-2023-12-15"
+    private let betaDescription = "prompt-caching-2024-07-31"
 
     func getAnthropicAPIHeaders() -> [String: String] {
         var headers: [String: String] = [

--- a/Sources/AnthropicSwiftSDK/Network/MessagesRequest.swift
+++ b/Sources/AnthropicSwiftSDK/Network/MessagesRequest.swift
@@ -19,7 +19,7 @@ public struct MessagesRequest: Encodable {
     /// System prompt.
     ///
     /// A system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role.
-    public let system: String?
+    public let system: [SystemPrompt]
     /// The maximum number of tokens to generate before stopping.
     ///
     /// Note that our models may stop before reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.
@@ -56,7 +56,7 @@ public struct MessagesRequest: Encodable {
     public init(
         model: Model = .claude_3_Opus,
         messages: [Message],
-        system: String? = nil,
+        system: [SystemPrompt] = [],
         maxTokens: Int,
         metaData: MetaData? = nil,
         stopSequences: [String]? = nil,

--- a/Tests/AnthropicSwiftSDK-BedrockTests/AnthropicBedrockClientTests.swift
+++ b/Tests/AnthropicSwiftSDK-BedrockTests/AnthropicBedrockClientTests.swift
@@ -12,7 +12,7 @@ import AWSBedrockRuntime
 
 final class AnthropicBedrockClientTests: XCTestCase {
     func testInvokeModelContainEncodedMessageRequest() throws {
-        let request = MessagesRequest(model: .claude_3_Haiku, messages: [Message(role: .user, content: [.text("Hello! Claude!")])], system: nil, maxTokens: 1024, metaData: MetaData(userId: "112234"), stopSequences: ["stop sequence"], stream: false, temperature: 0.4, topP: 1, topK: 2)
+        let request = MessagesRequest(model: .claude_3_Haiku, messages: [Message(role: .user, content: [.text("Hello! Claude!")])], system: [], maxTokens: 1024, metaData: MetaData(userId: "112234"), stopSequences: ["stop sequence"], stream: false, temperature: 0.4, topP: 1, topK: 2)
         let invokeModel = try InvokeModelInput(accept: "application/json", request: request, contentType: "application/json")
 
         let requestData = try XCTUnwrap(invokeModel.body)
@@ -29,7 +29,7 @@ final class AnthropicBedrockClientTests: XCTestCase {
     }
 
     func testInvokeModelNotContainUnnecessaryParameters() throws {
-        let request = MessagesRequest(model: .claude_3_Haiku, messages: [Message(role: .user, content: [.text("Hello! Claude!")])], system: nil, maxTokens: 1024, metaData: MetaData(userId: "112234"), stopSequences: ["stop sequence"], stream: false, temperature: 0.4, topP: 1, topK: 2)
+        let request = MessagesRequest(model: .claude_3_Haiku, messages: [Message(role: .user, content: [.text("Hello! Claude!")])], system: [], maxTokens: 1024, metaData: MetaData(userId: "112234"), stopSequences: ["stop sequence"], stream: false, temperature: 0.4, topP: 1, topK: 2)
         let invokeModel = try InvokeModelInput(accept: "application/json", request: request, contentType: "application/json")
 
         let requestData = try XCTUnwrap(invokeModel.body)
@@ -41,7 +41,7 @@ final class AnthropicBedrockClientTests: XCTestCase {
     }
 
     func testInvokeModelWithResponseStreamContainEncodedMessageRequest() throws {
-        let request = MessagesRequest(model: .claude_3_Haiku, messages: [Message(role: .user, content: [.text("Hello! Claude!")])], system: nil, maxTokens: 1024, metaData: MetaData(userId: "112234"), stopSequences: ["stop sequence"], stream: false, temperature: 0.4, topP: 1, topK: 2)
+        let request = MessagesRequest(model: .claude_3_Haiku, messages: [Message(role: .user, content: [.text("Hello! Claude!")])], system: [], maxTokens: 1024, metaData: MetaData(userId: "112234"), stopSequences: ["stop sequence"], stream: false, temperature: 0.4, topP: 1, topK: 2)
         let invokeModel = try InvokeModelWithResponseStreamInput(accept: "application/json", request: request, contentType: "application/json")
 
         let requestData = try XCTUnwrap(invokeModel.body)
@@ -58,7 +58,7 @@ final class AnthropicBedrockClientTests: XCTestCase {
     }
 
     func testInvokeModelWithResponseStreamNotContainUnnecessaryParameters() throws {
-        let request = MessagesRequest(model: .claude_3_Haiku, messages: [Message(role: .user, content: [.text("Hello! Claude!")])], system: nil, maxTokens: 1024, metaData: MetaData(userId: "112234"), stopSequences: ["stop sequence"], stream: false, temperature: 0.4, topP: 1, topK: 2)
+        let request = MessagesRequest(model: .claude_3_Haiku, messages: [Message(role: .user, content: [.text("Hello! Claude!")])], system: [], maxTokens: 1024, metaData: MetaData(userId: "112234"), stopSequences: ["stop sequence"], stream: false, temperature: 0.4, topP: 1, topK: 2)
         let invokeModel = try InvokeModelWithResponseStreamInput(accept: "application/json", request: request, contentType: "application/json")
 
         let requestData = try XCTUnwrap(invokeModel.body)
@@ -152,7 +152,7 @@ extension MessagesRequest: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(
             messages: try container.decode([Message].self, forKey: .messages),
-            system: try? container.decode(String.self, forKey: .system),
+            system: try container.decode([SystemPrompt].self, forKey: .system),
             maxTokens: try container.decode(Int.self, forKey: .maxTokens),
             stopSequences: try container.decode([String].self, forKey: .stopSequences),
             temperature: try container.decode(Double.self, forKey: .temperature),
@@ -221,3 +221,32 @@ extension Content: Equatable {
         }
     }
 }
+
+extension SystemPrompt: Equatable {
+    public static func == (lhs: SystemPrompt, rhs: SystemPrompt) -> Bool {
+        guard case let .text(lhsText, lhsCacheControl) = lhs,
+              case let .text(rhsText, rhsCacheControl) = rhs else {
+            return false
+        }
+
+        return lhsText == rhsText && lhsCacheControl == rhsCacheControl
+    }
+}
+
+extension SystemPrompt: Decodable {
+    enum CodingKeys: CodingKey {
+        case text
+        case cacheControl
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self = .text(
+            try container.decode(String.self, forKey: .text),
+            try? container.decode(CacheControl.self, forKey: .cacheControl)
+        )
+    }
+}
+
+extension CacheControl: Decodable {}

--- a/Tests/AnthropicSwiftSDKTests/Entity/SystemPromptTests.swift
+++ b/Tests/AnthropicSwiftSDKTests/Entity/SystemPromptTests.swift
@@ -1,0 +1,39 @@
+//
+//  SystemPromptTests.swift
+//  
+//
+//  Created by Fumito Ito on 2024/09/06.
+//
+
+import XCTest
+@testable import AnthropicSwiftSDK
+
+final class SystemPromptTests: XCTestCase {
+    let encoder = JSONEncoder()
+
+    func testEncodeSystemPrompt() throws {
+        let systemPrompt = SystemPrompt.text("this is test text for system prompt test", nil)
+        let dictionary = try XCTUnwrap(systemPrompt.toDictionary(encoder))
+
+        XCTAssertEqual(dictionary["type"] as? String, "text")
+        XCTAssertEqual(dictionary["text"] as? String, "this is test text for system prompt test")
+        XCTAssertNil(dictionary.index(forKey: "cache_control"))
+    }
+
+    func testEncodeSystemPromptWithCacheControl() throws {
+        let systemPrompt = SystemPrompt.text("this is test text for system prompt test with cache control", .ephemeral)
+        let dictionary = try XCTUnwrap(systemPrompt.toDictionary(encoder))
+
+        XCTAssertEqual(dictionary["type"] as? String, "text")
+        XCTAssertEqual(dictionary["text"] as? String, "this is test text for system prompt test with cache control")
+        let cacheControl = try XCTUnwrap(dictionary["cache_control"] as? [String: String])
+        XCTAssertEqual(cacheControl["type"], "ephemeral")
+    }
+}
+
+extension SystemPrompt {
+    func toDictionary(_ encoder: JSONEncoder) throws -> [String: Any]? {
+        let e = try encoder.encode(self)
+        return try JSONSerialization.jsonObject(with: e, options: []) as? [String: Any]
+    }
+}

--- a/Tests/AnthropicSwiftSDKTests/Network/AnthropicAPIClientTests.swift
+++ b/Tests/AnthropicSwiftSDKTests/Network/AnthropicAPIClientTests.swift
@@ -69,7 +69,7 @@ final class AnthropicAPIClientTests: XCTestCase {
             XCTAssertEqual(headers!["x-api-key"], "test-api-key")
             XCTAssertEqual(headers!["anthropic-version"], "2023-06-01")
             XCTAssertEqual(headers!["Content-Type"], "application/json")
-            XCTAssertEqual(headers!["anthropic-beta"], "messages-2023-12-15")
+            XCTAssertEqual(headers!["anthropic-beta"], "prompt-caching-2024-07-31")
 
             expectation.fulfill()
         })
@@ -90,7 +90,7 @@ final class AnthropicAPIClientTests: XCTestCase {
             XCTAssertEqual(headers!["x-api-key"], "test-api-key")
             XCTAssertEqual(headers!["anthropic-version"], "2023-06-01")
             XCTAssertEqual(headers!["Content-Type"], "application/json")
-            XCTAssertEqual(headers!["anthropic-beta"], "messages-2023-12-15")
+            XCTAssertEqual(headers!["anthropic-beta"], "prompt-caching-2024-07-31")
 
             expectation.fulfill()
         })

--- a/Tests/AnthropicSwiftSDKTests/Network/HeaderProvider/DefaultAnthropicHeaderProviderTests.swift
+++ b/Tests/AnthropicSwiftSDKTests/Network/HeaderProvider/DefaultAnthropicHeaderProviderTests.swift
@@ -29,7 +29,7 @@ final class DefaultAnthropicHeaderProviderTests: XCTestCase {
         let provider = DefaultAnthropicHeaderProvider(useBeta: true)
         let headers = provider.getAnthropicAPIHeaders()
 
-        XCTAssertEqual(headers["anthropic-beta"], "messages-2023-12-15")
+        XCTAssertEqual(headers["anthropic-beta"], "prompt-caching-2024-07-31")
     }
 
     func testBetaHeaderShouldNotBeProvidedIfUseBeta() {


### PR DESCRIPTION
refs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching

Prompt Caching is a powerful feature that optimizes your API usage by allowing resuming from specific prefixes in your prompts. This approach significantly reduces processing time and costs for repetitive tasks or prompts with consistent elements.

Here’s an example of how to implement Prompt Caching with the Messages API using a `cache_control` in system prompt.