### PR TITLE
Fix computer use issues

### DIFF
--- a/Sources/AnthropicSwiftSDK/Entity/Model.swift
+++ b/Sources/AnthropicSwiftSDK/Entity/Model.swift
@@ -52,7 +52,7 @@ extension Model {
         case .claude_3_Haiku:
             return "claude-3-haiku-20240307"
         case .claude_3_5_Sonnet:
-            return "claude-3-5-sonnet-20240620"
+            return "claude-3-5-sonnet-20241022"
         case let .custom(modelName):
             return modelName
         }

--- a/Sources/AnthropicSwiftSDK/Entity/Tool/Tool.swift
+++ b/Sources/AnthropicSwiftSDK/Entity/Tool/Tool.swift
@@ -56,4 +56,17 @@ public enum Tool {
     case function(FunctionTool)
 }
 
-extension Tool: Encodable {}
+extension Tool: Encodable {
+    public func encode(to encoder: any Encoder) throws {
+        switch self {
+        case .computer(let tool):
+            try tool.encode(to: encoder)
+        case .textEditor(let tool):
+            try tool.encode(to: encoder)
+        case .bash(let tool):
+            try tool.encode(to: encoder)
+        case .function(let tool):
+            try tool.encode(to: encoder)
+        }
+    }
+}

--- a/Tests/AnthropicSwiftSDKTests/Network/BatchResultResponseTests.swift
+++ b/Tests/AnthropicSwiftSDKTests/Network/BatchResultResponseTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class BatchResultResponseTests: XCTestCase {
     func testDecodeBatchResultResponseSucceeded() throws {
         let json = """
-        {"custom_id":"request_123","result":{"type":"succeeded","message":{"id":"msg_123456","type":"message","role":"assistant","model":"claude-3-5-sonnet-20240620","content":[{"type":"text","text":"Hello again! It's nice to see you. How can I assist you today? Is there anything specific you'd like to chat about or any questions you have?"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":11,"output_tokens":36}}}}
+        {"custom_id":"request_123","result":{"type":"succeeded","message":{"id":"msg_123456","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"Hello again! It's nice to see you. How can I assist you today? Is there anything specific you'd like to chat about or any questions you have?"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":11,"output_tokens":36}}}}
         """
         
         let jsonData = json.data(using: .utf8)!


### PR DESCRIPTION
### Version matching

Computer use only works with a newer model version of sonnet

### Tool encoding

Tools were being encoded as:
```json
"tools": [
  {
    "computer": {
      "_0": {
        "display_height_px": 768,
        "display_number": 1,
        "display_width_px": 1024,
        "type": "computer_20241022",
        "name": "computer"
      }
    }
  }
],
```

But they should be encoded as
```json
"tools": [
  {
    "display_number": 1,
    "name": "computer",
    "type": "computer_20241022",
    "display_width_px": 1024,
    "display_height_px": 768
  }
],
```